### PR TITLE
DEV-2320: Added custom Onc.AI build of `ohif-viewer-xnat`

### DIFF
--- a/.github/workflows/oncai-build.yaml
+++ b/.github/workflows/oncai-build.yaml
@@ -1,0 +1,31 @@
+name: Build
+
+on:
+  pull_request:
+  workflow_dispatch:
+  release:
+    types:
+      - published
+
+jobs:
+  all:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build
+        run: |
+          mkdir -p output
+          docker build -t ohif-viewer-xnat-build -f oncai/Dockerfile oncai
+          docker run --rm -e VERSION=oncai${{ github.event.release.tag_name }} \
+            -v $(pwd):/plugin/ohifviewerxnat \
+            -v $(pwd)/output:/plugin/output \
+            ohif-viewer-xnat-build
+
+      - name: Release
+        if: ${{ github.event_name == 'release' }}
+        uses: softprops/action-gh-release@v1
+        with:
+          files: output/libs/ohif-viewer-3.6.0-fat-oncai${{ github.event.release.tag_name }}.jar

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+***
+***
+***
+***
+> NOTE: Onc.AI should refer to this [README.md](./oncai/README.md) instead, as
+> it covers the details, installation, and motivation for the fork.
+***
+***
+***
+***
+
 # OHIF-Viewer-XNAT
 
 ***The OHIF-XNAT viewer is based on a fork of [OHIF Viewer 2.0](https://github.com/OHIF/Viewers) and uses the [React](https://reactjs.org/) JavaScript library.***

--- a/oncai/Dockerfile
+++ b/oncai/Dockerfile
@@ -1,0 +1,18 @@
+FROM tomcat:9-jdk8-temurin-jammy AS base
+ENV NODE_OPTIONS=--openssl-legacy-provider
+RUN apt-get update && apt-get install --yes --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+    ; \
+    mkdir -p /etc/apt/keyrings; \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \
+    apt-get update && apt-get install --yes --no-install-recommends nodejs; \
+    npm install -g yarn;
+
+FROM base AS plugin
+RUN git clone --depth=1 --branch=3.6.0 https://bitbucket.org/icrimaginginformatics/ohif-viewer-xnat-plugin.git /plugin
+COPY run.sh /
+ENTRYPOINT ["/run.sh"]

--- a/oncai/README.md
+++ b/oncai/README.md
@@ -1,0 +1,59 @@
+# Onc.AI Fork of `ohif-viewer-xnat`
+
+This repository exists only to serve as an intermediate source for
+the `ohif-viewer-xnat` plugin.
+
+Changes are based on:
+* https://bitbucket.org/icrimaginginformatics/ohif-viewer-xnat-plugin.git = `v3.6.0`
+* https://bitbucket.org/icrimaginginformatics/ohif-viewer-xnat.git = `v3.6.0`
+* XNAT v1.8.7+ is required for the above plugin.
+
+# Installation
+
+> NOTE: Follow these steps carefully; you can break Tomcat.
+
+In your XNATs `data` directory, there is a `plugins` directory where
+all loadable plugins will live. The current OHIF viewer plugin should
+live there.
+
+> NOTE: Due to how XNAT installations vary per-installation, I can't
+provide actual names and paths -- they may not match. It is up to you
+to find the appropriate paths.
+
+The steps for installing this library are as follows:
+
+* Shutdown XNAT
+* Remove the existing OHIF viewer `.jar` file from the plugins directory.
+  * Or 'move' it to some other directory
+* Start XNAT
+* Confirm in the XNAT admin UI that the OHIF Viewer plugin is not installed
+  * You shouldn't be able to view images on subjects.
+* Shutdown XNAT
+* Copy the Onc.AI version of the OHIF Viewer `.jar` file to the same
+plugins directory where you removed the old `.jar`.
+* Start XNAT again.
+* Ensure that:
+  * The OHIF Viewer plugin is installed
+  * You can view subject imaging
+
+At this point in time, the new XNAT OHIF Viewer image is installed.
+
+> NOTE: If your browser has viewed a JPEG/2000 image with the old plugin
+installed, you will need to invalidate/clear your browser image cache,
+as the old image will be presented. This can also be confirmed using
+a "private browsing" window.
+
+## Motivation(s)
+
+### Issue: Blurry JPEG/2000 DICOM images
+
+https://onc-ai.atlassian.net/browse/DEV-2320
+
+An issue exists in XNAT 1.8.9 where jpeg/2000 DICOM images appear
+blurry.
+
+The underlying fix is to upgrade the `cornerstone-wado-image-loader` library that exists in the plugins embedded `ohif-viewer-xnat` submodule
+(effectively what this repository mirrors).
+
+The plan is that a pull-request will be made upstream so that this
+change will be included in an official release.

--- a/oncai/run.sh
+++ b/oncai/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eu
+
+cd /plugin
+./build_plugin.sh
+
+mkdir -p /plugin/output
+mv /plugin/build/* /plugin/output
+
+cd /plugin/output/libs
+mv ohif-viewer-3.6.0-fat.jar ohif-viewer-3.6.0-fat-${VERSION}.jar


### PR DESCRIPTION
This adds a simple `Dockerfile` that creates the proper build environment for building `ohif-viewer-xnat`.

A GHA workflow that publishes build artifacts in the releases page has also been added.
